### PR TITLE
Update webpack configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hubot-azure-alert-notifier",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "Notify for configured alert webhooks set on Microsoft Azure.",
   "main": "dist/index.js",
   "license": "MIT",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,8 @@ module.exports = {
 
 	output: {
 		path: 'dist',
-		filename: 'index.js'
+		filename: 'index.js',
+		libraryTarget: 'commonjs2'
 	},
 
 	target: 'node',


### PR DESCRIPTION
The existing webpack configuration wasn't working as expected. By setting `libraryTarget: 'commonjs2'` -- everything works now!

Update version to **0.1.1**.
